### PR TITLE
Fix imageio error in colab notebooks

### DIFF
--- a/notebooks/DataManagement/02_load_files.ipynb
+++ b/notebooks/DataManagement/02_load_files.ipynb
@@ -451,7 +451,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/notebooks/ImageAnalysis/01_exploration.ipynb
+++ b/notebooks/ImageAnalysis/01_exploration.ipynb
@@ -77,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q ipympl numpy matplotlib pydicom imageio==2.34"
+    "%pip install -q ipympl numpy matplotlib pydicom imageio"
    ]
   },
   {
@@ -119,6 +119,7 @@
    "outputs": [],
    "source": [
     "# Initial imports etc\n",
+    "import os\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
@@ -383,7 +384,12 @@
    "metadata": {},
    "source": [
     "# Load volumes\n",
-    "ImageIO's `volread()` function can load multi-dimensional datasets and create 3D volumes from a folder of images. It can also aggregate metadata across these multiple images."
+    "We would like to understand how 3D data can now be loaded. Our data set (3D volume) consists of 27 individual 2D slices. We now need to complete the following steps:\n",
+    "- Read in the DICOM slices with `pydicom.dcmread()`\n",
+    "- Sort by InstanceNumber (this ensures the correct order of the individual slices)\n",
+    "- Read out the pixel values and then stack them together to form a 3D volume\n",
+    "\n",
+    "An alternative: ImageIO's `volread()` function can load multi-dimensional datasets and create 3D volumes from a folder of images. It can also aggregate metadata across these multiple images."
    ]
   },
   {
@@ -395,11 +401,61 @@
     "# Path to the folder containing the DICOM files\n",
     "folder_path = 'Data/Brain/SE000001'\n",
     "\n",
-    "# Load the brain data folder\n",
-    "vol = imageio.volread(folder_path, 'DICOM')\n",
+    "# Read all DICOM files into a list\n",
+    "dicoms = [pydicom.dcmread(os.path.join(folder_path, f)) for f in os.listdir(folder_path) if f.endswith('.dcm')]\n",
+    "\n",
+    "# Sort the list by InstanceNumber\n",
+    "dicoms.sort(key=lambda x: int(x.InstanceNumber))\n",
+    "\n",
+    "# Initialize an empty list to hold all slices\n",
+    "slices = []\n",
+    "\n",
+    "# Save the pixel data slice by slice\n",
+    "for dcm in dicoms:\n",
+    "    pixel_data = dcm.pixel_array\n",
+    "    slices.append(pixel_data)\n",
+    "\n",
+    "# Convert the list of slices into a 3D numpy array\n",
+    "vol = np.stack(slices)\n",
     "\n",
     "# Print image attributes (similar to pydicom)\n",
     "print('Shape of image array:', vol.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since we need the code again in later notebooks, a function would be useful."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def read_dicom_volume(folder_path):\n",
+    "    # Read all DICOM files into a list\n",
+    "    dicoms = [pydicom.dcmread(os.path.join(folder_path, f)) for f in os.listdir(folder_path) if f.endswith('.dcm')]\n",
+    "\n",
+    "    # Sort the list by InstanceNumber\n",
+    "    dicoms.sort(key=lambda x: int(x.InstanceNumber))\n",
+    "\n",
+    "    # Initialize an empty list to hold all slices\n",
+    "    slices = []\n",
+    "\n",
+    "    # Save the pixel data slice by slice\n",
+    "    for dcm in dicoms:\n",
+    "        pixel_data = dcm.pixel_array\n",
+    "        slices.append(pixel_data)\n",
+    "\n",
+    "    # Convert the list of slices into a 3D numpy array\n",
+    "    vol = np.stack(slices)\n",
+    "\n",
+    "    return vol\n",
+    "\n",
+    "vol = read_dicom_volume(folder_path)"
    ]
   },
   {
@@ -441,15 +497,20 @@
    "outputs": [],
    "source": [
     "# Plot the images on a subplots array \n",
-    "fig, axes = plt.subplots(nrows=1,ncols=3)\n",
+    "fig, axes = plt.subplots(nrows=3, ncols=3)\n",
+    "\n",
+    "# Flatten the 2D axes array to make indexing easier\n",
+    "axes = axes.flatten()\n",
     "\n",
     "# Loop through subplots and draw image\n",
-    "# plot every 10th slice of vol on a separate subplot\n",
-    "for ii in range(3):\n",
-    "    im = vol[ii*10, :, :]\n",
+    "# plot every 3rd slice of vol on a separate subplot\n",
+    "for ii in range(9):\n",
+    "    im = vol[ii*3, :, :]\n",
     "    axes[ii].imshow(im, cmap='gray')\n",
     "    axes[ii].axis('off')\n",
-    "    \n",
+    "\n",
+    "plt.tight_layout() # Adjust the subplots to fit into the figure area\n",
+    "\n",
     "# Render the figure\n",
     "plt.show()"
    ]
@@ -474,7 +535,8 @@
     "im1 = vol[:, 128, :]\n",
     "\n",
     "# Compute aspect ratios\n",
-    "d0, d1, d2 = vol.meta['sampling']\n",
+    "d0 = dicoms[0].SliceThickness\n",
+    "d1, d2 = dicoms[0].PixelSpacing\n",
     "asp1 = d0 / d2\n",
     "\n",
     "# Plot the coronal image\n",

--- a/notebooks/ImageAnalysis/02_image_comparison.ipynb
+++ b/notebooks/ImageAnalysis/02_image_comparison.ipynb
@@ -81,7 +81,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q ipympl numpy matplotlib imageio==2.34 SciPy scikit-image"
+    "%pip install -q ipympl numpy matplotlib pydicom imageio SciPy scikit-image"
    ]
   },
   {
@@ -94,6 +94,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "import imageio\n",
+    "import pydicom\n",
     "import scipy.ndimage as ndi\n",
     "from skimage.metrics import structural_similarity as ssim"
    ]
@@ -123,10 +124,12 @@
    "outputs": [],
    "source": [
     "# Initial imports etc\n",
+    "import os\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "import imageio\n",
+    "import pydicom\n",
     "import scipy.ndimage as ndi\n",
     "from skimage.metrics import structural_similarity as ssim"
    ]
@@ -162,6 +165,40 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The following fuction `read_dicom_volume()` is from the notebook `01_exploration.ipynb` and is reused here:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def read_dicom_volume(folder_path):\n",
+    "    # Read all DICOM files into a list\n",
+    "    dicoms = [pydicom.dcmread(os.path.join(folder_path, f)) for f in os.listdir(folder_path) if f.endswith('.dcm')]\n",
+    "\n",
+    "    # Sort the list by InstanceNumber\n",
+    "    dicoms.sort(key=lambda x: int(x.InstanceNumber))\n",
+    "\n",
+    "    # Initialize an empty list to hold all slices\n",
+    "    slices = []\n",
+    "\n",
+    "    # Save the pixel data slice by slice\n",
+    "    for dcm in dicoms:\n",
+    "        pixel_data = dcm.pixel_array\n",
+    "        slices.append(pixel_data)\n",
+    "\n",
+    "    # Convert the list of slices into a 3D numpy array\n",
+    "    vol = np.stack(slices)\n",
+    "\n",
+    "    return vol"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Load the Image/Volume\n",
     "In this chapter, we'll leverage data use data from the OASIS to compare the brains of different populations: young and old, male and female, healthy and diseased."
    ]
@@ -176,7 +213,7 @@
     "folder_path = 'Data/Brain/SE000001'\n",
     "\n",
     "# Load the volume\n",
-    "vol = imageio.volread(folder_path, 'DICOM')\n",
+    "vol = read_dicom_volume(folder_path)\n",
     "print(vol.shape)\n",
     "\n",
     "# save the middle slice as separat image\n",

--- a/notebooks/ImageAnalysis/04_measurements.ipynb
+++ b/notebooks/ImageAnalysis/04_measurements.ipynb
@@ -77,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q ipympl numpy matplotlib imageio==2.34 SciPy"
+    "%pip install -q ipympl numpy matplotlib pydicom imageio SciPy"
    ]
   },
   {
@@ -90,6 +90,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "import imageio\n",
+    "import pydicom\n",
     "import scipy.ndimage as ndi"
    ]
   },
@@ -118,10 +119,12 @@
    "outputs": [],
    "source": [
     "# Initial imports etc\n",
+    "import os\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "import imageio\n",
+    "import pydicom\n",
     "import scipy.ndimage as ndi"
    ]
   },
@@ -166,6 +169,40 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The following fuction `read_dicom_volume()` is from the notebook `01_exploration.ipynb` and is reused here:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def read_dicom_volume(folder_path):\n",
+    "    # Read all DICOM files into a list\n",
+    "    dicoms = [pydicom.dcmread(os.path.join(folder_path, f)) for f in os.listdir(folder_path) if f.endswith('.dcm')]\n",
+    "\n",
+    "    # Sort the list by InstanceNumber\n",
+    "    dicoms.sort(key=lambda x: int(x.InstanceNumber))\n",
+    "\n",
+    "    # Initialize an empty list to hold all slices\n",
+    "    slices = []\n",
+    "\n",
+    "    # Save the pixel data slice by slice\n",
+    "    for dcm in dicoms:\n",
+    "        pixel_data = dcm.pixel_array\n",
+    "        slices.append(pixel_data)\n",
+    "\n",
+    "    # Convert the list of slices into a 3D numpy array\n",
+    "    vol = np.stack(slices)\n",
+    "\n",
+    "    return vol"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Load the Image/Volume"
    ]
   },
@@ -179,7 +216,7 @@
     "folder_path = 'Data/Brain/SE000001'\n",
     "\n",
     "# Load the volume\n",
-    "vol = imageio.volread(folder_path, 'DICOM')\n",
+    "vol = read_dicom_volume(folder_path)\n",
     "print(vol.shape)\n",
     "\n",
     "# save the middle slice as separat image\n",


### PR DESCRIPTION
imageio has been replaced by its own function (with pydicom) in notebooks. Error has been eliminated.